### PR TITLE
fix build

### DIFF
--- a/input/fsh/EX_Staging_Other.fsh
+++ b/input/fsh/EX_Staging_Other.fsh
@@ -1,3 +1,14 @@
+
+Alias: FMM = http://hl7.org/fhir/StructureDefinition/structuredefinition-fmm
+
+RuleSet: StagingInstanceRuleSet
+* status = #final "final"
+* focus = Reference(primary-cancer-condition-nonspecific)
+* subject = Reference(cancer-patient-john-anyperson)
+* performer = Reference(us-core-practitioner-kyle-anydoc)
+* effectiveDateTime = "2023-09-01"
+
+
 Instance: all-fab-classification-M5b
 InstanceOf: ALLClassification
 Description: "Example of FAB (French-American-British) staging of acute lymphoblastic leukemia (ALL)."

--- a/input/fsh/SD_Staging_Other.fsh
+++ b/input/fsh/SD_Staging_Other.fsh
@@ -37,7 +37,7 @@ Description: "Phase of Chronic Myeloid Leukemia (CML) observed at a specified po
 
 Profile: FABClassification
 Id: pedcan-fab-classification
-Parent: CancerStageGroup  // ?
+Parent: CancerStage ///Group  // ?
 Title: "FAB Classification for acute lymphoblastic leukemia"
 Description: "Binet stage for acute lymphoblastic leukemia"
 * insert NotUsed(component)

--- a/sushi-config.yaml
+++ b/sushi-config.yaml
@@ -25,7 +25,7 @@ publisher:
 #
 dependencies:
   hl7.fhir.us.core: 5.0.1
-  hl7.fhir.us.mcode: 3.0.0-ballot
+  hl7.fhir.us.mcode: current
   hl7.fhir.uv.genomics-reporting: 2.0.0
 #
 # The parameters property represents IG.definition.parameter. Rather


### PR DESCRIPTION
1) THere was a reference to a ruleset from mCODE.  Rulesets aren’t really part of the published IG, so they need to be copied into the IG.  Note that the resources referenced by the the ruleset don't resolve, so that generates some build errors.
2) There was a reference to CancerStageGroup.  I changed that to CancerStage.
3) There was a reference to FMM, but the Alias FMM wasn’t defined in this IG.
4) dependency should be on current build of mCODE (soon to be published as STU3), STU3-ballot, which is pretty old by now.